### PR TITLE
Async performActivity

### DIFF
--- a/Pod/Classes/TUSafariActivity.m
+++ b/Pod/Classes/TUSafariActivity.m
@@ -81,9 +81,13 @@
 
 - (void)performActivity
 {
-	BOOL completed = [[UIApplication sharedApplication] openURL:_URL];
-	
-	[self activityDidFinish:completed];
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+        BOOL completed = [[UIApplication sharedApplication] openURL:_URL];
+
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf activityDidFinish:completed];
+    });
 }
 
 @end

--- a/TUSafariActivity.podspec
+++ b/TUSafariActivity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "TUSafariActivity"
-  s.version          = "1.0.4"
+  s.version          = "1.0.5"
   s.summary          = "A UIActivity subclass that opens URLs in Safari."
   s.homepage     = "https://github.com/davbeck/TUSafariActivity"
   s.screenshots  = "http://f.cl.ly/items/3e3W360A0f0v0Z392u0W/iOS%20Simulator%20Screen%20Shot%20Oct%204,%202014,%2011.54.20%20AM.png"


### PR DESCRIPTION
Allows application to stay responsive if `[[UIApplication sharedApplication] openURL:_URL]` responds slowly (ex: page is slow to load).

I encountered a problem where, on first call to "Open in Safari" after a fresh install, the application would hang for ~5 seconds before context switching to Safari. After this change, the application switches to Safari while the page is being loaded.