### PR TITLE
Fix xcodebuild command line error

### DIFF
--- a/TUSafariActivity.podspec
+++ b/TUSafariActivity.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/davbeck/TUSafariActivity.git", :tag => s.version.to_s }
   s.requires_arc = true
   s.source_files = 'Pod/Classes'
-  s.resources = Pod/Assets/*
+  s.resources = 'Pod/Assets/*'
 end

--- a/TUSafariActivity.podspec
+++ b/TUSafariActivity.podspec
@@ -11,7 +11,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/davbeck/TUSafariActivity.git", :tag => s.version.to_s }
   s.requires_arc = true
   s.source_files = 'Pod/Classes'
-  s.resource_bundles = {
-    'TUSafariActivity' => ['Pod/Assets/*']
-  }
+  s.resources = Pod/Assets/*
 end


### PR DESCRIPTION
Fix for this error when you do a command line xcodebuild
error: Resource "XXXX/DerivedData/Build/Intermediates/ArchiveIntermediates/CarPool/BuildProductsPath/Release-iphoneos/TUSafariActivity/TUSafariActivity.bundle" not found. Run 'pod install' to update the copy resources script.
